### PR TITLE
Add missing includes preventing compilation in VS 2019.

### DIFF
--- a/P2P/ConnectionManager.h
+++ b/P2P/ConnectionManager.h
@@ -12,6 +12,7 @@
 #include <shared_mutex>
 #include <thread>
 #include <set>
+#include <unordered_map>
 
 // Forward Declarations
 class PeerManager;

--- a/PMMR/Zip/ZipFile.h
+++ b/PMMR/Zip/ZipFile.h
@@ -7,6 +7,7 @@
 	#define USEWIN32IOAPI
 #endif
 
+#include <string>
 #include <vector>
 
 enum class EZipFileStatus

--- a/TxPool/Pool.cpp
+++ b/TxPool/Pool.cpp
@@ -6,6 +6,7 @@
 #include <Infrastructure/Logger.h>
 #include <Core/Validation/TransactionValidator.h>
 #include <algorithm>
+#include <unordered_map>
 
 Pool::Pool(const Config& config, const TxHashSetManager& txHashSetManager, const IBlockDB& blockDB)
 	: m_config(config), m_txHashSetManager(txHashSetManager), m_blockDB(blockDB)


### PR DESCRIPTION
This fixes compilation in VS 2019. I think it's harmless for VS 2017.