### PR TITLE
add missing includes to fix build regression

### DIFF
--- a/src/P2P/Pipeline/TxHashSetPipe.cpp
+++ b/src/P2P/Pipeline/TxHashSetPipe.cpp
@@ -10,6 +10,8 @@
 #include <Infrastructure/Logger.h>
 #include <BlockChain/BlockChainServer.h>
 
+#include <filesystem.h>
+
 static const int BUFFER_SIZE = 256 * 1024;
 
 TxHashSetPipe::TxHashSetPipe(

--- a/src/PMMR/Common/LeafSet.h
+++ b/src/PMMR/Common/LeafSet.h
@@ -12,6 +12,8 @@
 #include <Common/Util/FileUtil.h>
 #include <Core/Serialization/Serializer.h>
 
+#include <filesystem.h>
+
 class LeafSet
 {
 public:

--- a/src/PMMR/TxHashSetManager.cpp
+++ b/src/PMMR/TxHashSetManager.cpp
@@ -8,6 +8,8 @@
 #include <Common/Util/StringUtil.h>
 #include <Infrastructure/Logger.h>
 
+#include <filesystem.h>
+
 TxHashSetManager::TxHashSetManager(const Config& config)
 	: m_config(config), m_pTxHashSet(nullptr)
 {


### PR DESCRIPTION
When pulling master I noticed I was unable to build the project due to undefined references for the `filesystem.h` library. I bisected to find that there appeared to be an issue with `a8f1ff15c517201b58227ec89483b3b7b1e14202`. I have added the missing includes for the filesystem interface. Feel free to close and write yourself or suggest anything you would like to see changed :)