### PR TITLE
Using POST instead of GET to estimate fee

### DIFF
--- a/src/Server/Wallet/API/OwnerGetAPI.cpp
+++ b/src/Server/Wallet/API/OwnerGetAPI.cpp
@@ -55,13 +55,6 @@ int OwnerGetAPI::HandleGET(mg_connection* pConnection, const std::string& action
 		return RetrieveOutputs(pConnection, walletManager, token);
 	}
 
-	// GET /v1/wallet/owner/estimate_fee
-	if (action == "estimate_fee")
-	{
-		const SessionToken token = SessionTokenUtil::GetSessionToken(*pConnection);
-		return EstimateFee(pConnection, walletManager, token);
-	}
-
 	// GET /v1/wallet/owner/retrieve_txs?refresh&id=x
 	if (action == "retrieve_txs")
 	{
@@ -89,43 +82,6 @@ int OwnerGetAPI::RetrieveSummaryInfo(mg_connection* pConnection, IWalletManager&
 	return HTTPUtil::BuildSuccessResponse(pConnection, walletSummary.ToJSON().toStyledString());
 }
 
-// GET /v1/wallet/owner/estimate_fee
-int OwnerGetAPI::EstimateFee(mg_connection* pConnection, IWalletManager& walletManager, const SessionToken& token)
-{
-	std::optional<Json::Value> requestBodyOpt = HTTPUtil::GetRequestBody(pConnection);
-	if (!requestBodyOpt.has_value())
-	{
-		return HTTPUtil::BuildBadRequestResponse(pConnection, "Request body not found.");
-	}
-
-	const Json::Value& json = requestBodyOpt.value();
-
-	const std::optional<uint64_t> amountOpt = JsonUtil::GetUInt64Opt(json, "amount");
-	if (!amountOpt.has_value())
-	{
-		return HTTPUtil::BuildBadRequestResponse(pConnection, "amount missing");
-	}
-
-	const Json::Value feeBaseJSON = json.get("fee_base", Json::nullValue);
-	if (feeBaseJSON == Json::nullValue || !feeBaseJSON.isUInt64())
-	{
-		return HTTPUtil::BuildBadRequestResponse(pConnection, "fee_base missing");
-	}
-
-	const std::optional<std::string> messageOpt = JsonUtil::GetStringOpt(json, "message");
-
-	const std::optional<Json::Value> selectionStrategyJSON = JsonUtil::GetOptionalField(json, "selection_strategy");
-	if (!selectionStrategyJSON.has_value())
-	{
-		return HTTPUtil::BuildBadRequestResponse(pConnection, "selection_strategy missing");
-	}
-
-	const SelectionStrategyDTO selectionStrategy = SelectionStrategyDTO::FromJSON(selectionStrategyJSON.value());
-	const uint8_t numOutputs = (uint8_t)json.get("change_outputs", Json::Value(1)).asUInt();
-	const FeeEstimateDTO estimatedFee = walletManager.EstimateFee(token, amountOpt.value(), feeBaseJSON.asUInt64(), selectionStrategy, numOutputs);
-
-	return HTTPUtil::BuildSuccessResponseJSON(pConnection, estimatedFee.ToJSON());
-}
 
 // GET /v1/wallet/owner/retrieve_txs?refresh&id=x
 int OwnerGetAPI::RetrieveTransactions(mg_connection* pConnection, IWalletManager& walletManager, const SessionToken& token)

--- a/src/Server/Wallet/API/OwnerGetAPI.h
+++ b/src/Server/Wallet/API/OwnerGetAPI.h
@@ -17,5 +17,4 @@ private:
 	static int RetrieveSummaryInfo(mg_connection* pConnection, IWalletManager& walletManager, const SessionToken& token);
 	static int RetrieveTransactions(mg_connection* pConnection, IWalletManager& walletManager, const SessionToken& token);
 	static int RetrieveOutputs(mg_connection* pConnection, IWalletManager& walletManager, const SessionToken& token);
-	static int EstimateFee(mg_connection* pConnection, IWalletManager& walletManager, const SessionToken& token);
 };

--- a/src/Server/Wallet/API/OwnerPostAPI.cpp
+++ b/src/Server/Wallet/API/OwnerPostAPI.cpp
@@ -67,6 +67,11 @@ int OwnerPostAPI::HandlePOST(mg_connection* pConnection, const std::string& acti
 	{
 		return Finalize(pConnection, walletManager, requestBodyOpt.value());
 	}
+	else if (action == "estimate_fee")
+	{
+		const SessionToken token = SessionTokenUtil::GetSessionToken(*pConnection);
+		return EstimateFee(pConnection, walletManager, token);
+	}
 
 	return HTTPUtil::BuildBadRequestResponse(pConnection, "POST /v1/wallet/owner/" + action + " not Supported");
 }
@@ -242,4 +247,41 @@ int OwnerPostAPI::Cancel(mg_connection* pConnection, IWalletManager& walletManag
 	{
 		return HTTPUtil::BuildBadRequestResponse(pConnection, "id missing");
 	}
+}
+
+int OwnerGetAPI::EstimateFee(mg_connection* pConnection, IWalletManager& walletManager, const SessionToken& token)
+{
+	std::optional<Json::Value> requestBodyOpt = HTTPUtil::GetRequestBody(pConnection);
+	if (!requestBodyOpt.has_value())
+	{
+		return HTTPUtil::BuildBadRequestResponse(pConnection, "Request body not found.");
+	}
+
+	const Json::Value& json = requestBodyOpt.value();
+
+	const std::optional<uint64_t> amountOpt = JsonUtil::GetUInt64Opt(json, "amount");
+	if (!amountOpt.has_value())
+	{
+		return HTTPUtil::BuildBadRequestResponse(pConnection, "amount missing");
+	}
+
+	const Json::Value feeBaseJSON = json.get("fee_base", Json::nullValue);
+	if (feeBaseJSON == Json::nullValue || !feeBaseJSON.isUInt64())
+	{
+		return HTTPUtil::BuildBadRequestResponse(pConnection, "fee_base missing");
+	}
+
+	const std::optional<std::string> messageOpt = JsonUtil::GetStringOpt(json, "message");
+
+	const std::optional<Json::Value> selectionStrategyJSON = JsonUtil::GetOptionalField(json, "selection_strategy");
+	if (!selectionStrategyJSON.has_value())
+	{
+		return HTTPUtil::BuildBadRequestResponse(pConnection, "selection_strategy missing");
+	}
+
+	const SelectionStrategyDTO selectionStrategy = SelectionStrategyDTO::FromJSON(selectionStrategyJSON.value());
+	const uint8_t numOutputs = (uint8_t)json.get("change_outputs", Json::Value(1)).asUInt();
+	const FeeEstimateDTO estimatedFee = walletManager.EstimateFee(token, amountOpt.value(), feeBaseJSON.asUInt64(), selectionStrategy, numOutputs);
+
+	return HTTPUtil::BuildSuccessResponseJSON(pConnection, estimatedFee.ToJSON());
 }

--- a/src/Server/Wallet/API/OwnerPostAPI.cpp
+++ b/src/Server/Wallet/API/OwnerPostAPI.cpp
@@ -249,7 +249,7 @@ int OwnerPostAPI::Cancel(mg_connection* pConnection, IWalletManager& walletManag
 	}
 }
 
-int OwnerGetAPI::EstimateFee(mg_connection* pConnection, IWalletManager& walletManager, const SessionToken& token)
+int OwnerPostAPI::EstimateFee(mg_connection* pConnection, IWalletManager& walletManager, const SessionToken& token)
 {
 	std::optional<Json::Value> requestBodyOpt = HTTPUtil::GetRequestBody(pConnection);
 	if (!requestBodyOpt.has_value())

--- a/src/Server/Wallet/API/OwnerPostAPI.cpp
+++ b/src/Server/Wallet/API/OwnerPostAPI.cpp
@@ -70,7 +70,7 @@ int OwnerPostAPI::HandlePOST(mg_connection* pConnection, const std::string& acti
 	else if (action == "estimate_fee")
 	{
 		const SessionToken token = SessionTokenUtil::GetSessionToken(*pConnection);
-		return EstimateFee(pConnection, walletManager, token);
+		return EstimateFee(pConnection, walletManager, token, requestBodyOpt.value());
 	}
 
 	return HTTPUtil::BuildBadRequestResponse(pConnection, "POST /v1/wallet/owner/" + action + " not Supported");
@@ -249,16 +249,8 @@ int OwnerPostAPI::Cancel(mg_connection* pConnection, IWalletManager& walletManag
 	}
 }
 
-int OwnerPostAPI::EstimateFee(mg_connection* pConnection, IWalletManager& walletManager, const SessionToken& token)
+int OwnerPostAPI::EstimateFee(mg_connection* pConnection, IWalletManager& walletManager, const SessionToken& token, const Json::Value& json)
 {
-	std::optional<Json::Value> requestBodyOpt = HTTPUtil::GetRequestBody(pConnection);
-	if (!requestBodyOpt.has_value())
-	{
-		return HTTPUtil::BuildBadRequestResponse(pConnection, "Request body not found.");
-	}
-
-	const Json::Value& json = requestBodyOpt.value();
-
 	const std::optional<uint64_t> amountOpt = JsonUtil::GetUInt64Opt(json, "amount");
 	if (!amountOpt.has_value())
 	{

--- a/src/Server/Wallet/API/OwnerPostAPI.h
+++ b/src/Server/Wallet/API/OwnerPostAPI.h
@@ -29,7 +29,7 @@ private:
 	int Repost(mg_connection* pConnection, IWalletManager& walletManager, const SessionToken& token);
 	int Cancel(mg_connection* pConnection, IWalletManager& walletManager, const SessionToken& token);
 
-	int EstimateFee(mg_connection* pConnection, IWalletManager& walletManager, const SessionToken& token);
+	int EstimateFee(mg_connection* pConnection, IWalletManager& walletManager, const SessionToken& token, const Json::Value& json);
 
 	const Config& m_config;
 };

--- a/src/Server/Wallet/API/OwnerPostAPI.h
+++ b/src/Server/Wallet/API/OwnerPostAPI.h
@@ -29,5 +29,7 @@ private:
 	int Repost(mg_connection* pConnection, IWalletManager& walletManager, const SessionToken& token);
 	int Cancel(mg_connection* pConnection, IWalletManager& walletManager, const SessionToken& token);
 
+	int EstimateFee(mg_connection* pConnection, IWalletManager& walletManager, const SessionToken& token);
+
 	const Config& m_config;
 };


### PR DESCRIPTION
Right now the `estimate_fee` endpoint is not compatible with NodeJs. This PR move the endpoint from GET to POST.