### PR TITLE
Using python@3.10 on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,8 @@ jobs:
           brew install gcc cmake
           echo "::set-env name=CC::gcc-${{ matrix.version }}"
           echo "::set-env name=CXX::g++-${{ matrix.version }}"
-          brew install gflags
+          brew install gflags python@3.10
+          ln -s -f /usr/local/bin/python3.10 /usr/local/bin/python
         env:
             ACTIONS_ALLOW_UNSECURE_COMMANDS: true
       - name: setup ubuntu environment


### PR DESCRIPTION
Help to prevent the next building error:

```
2024-10-22T07:58:06.7021540Z v1.2.9
2024-10-22T07:58:07.0943380Z 
2024-10-22T07:58:07.0945110Z > grinplusplus@1.2.9 clean_build:nix /Users/runner/work/GrinPlusPlus/GrinPlusPlus/frontend
2024-10-22T07:58:07.0948100Z > rm -rf node_modules/ && npm install && npm run build && cp -R ./assets/icons ./build/ && cp ./src/electron-starter.js ./build/ && cp ./src/notarize.js ./build/ && cp entitlements.mac.plist ./build/
2024-10-22T07:58:07.0950780Z 
2024-10-22T07:59:35.8696240Z 
2024-10-22T07:59:35.9699530Z > fsevents@1.2.13 install /Users/runner/work/GrinPlusPlus/GrinPlusPlus/frontend/node_modules/jest-haste-map/node_modules/fsevents
2024-10-22T07:59:35.9991950Z > node install.js
2024-10-22T07:59:35.9992430Z 
2024-10-22T07:59:38.1660080Z Traceback (most recent call last):
2024-10-22T07:59:38.1680520Z   File "/Users/runner/hostedtoolcache/node/14.21.3/x64/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp_main.py", line 50, in <module>
2024-10-22T07:59:38.1694280Z     sys.exit(gyp.script_main())
2024-10-22T07:59:38.1717810Z              ^^^^^^^^^^^^^^^^^
2024-10-22T07:59:38.1739550Z   File "/Users/runner/hostedtoolcache/node/14.21.3/x64/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/__init__.py", line 554, in script_main
2024-10-22T07:59:38.1741450Z     return main(sys.argv[1:])
2024-10-22T07:59:38.1755300Z            ^^^^^^^^^^^^^^^^^^
2024-10-22T07:59:38.1772960Z   File "/Users/runner/hostedtoolcache/node/14.21.3/x64/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/__init__.py", line 547, in main
2024-10-22T07:59:38.1790300Z     return gyp_main(args)
2024-10-22T07:59:38.1801080Z            ^^^^^^^^^^^^^^
2024-10-22T07:59:38.1837760Z   File "/Users/runner/hostedtoolcache/node/14.21.3/x64/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/__init__.py", line 520, in gyp_main
2024-10-22T07:59:38.1869740Z     [generator, flat_list, targets, data] = Load(
2024-10-22T07:59:38.1882600Z                                             ^^^^^
2024-10-22T07:59:38.1923090Z   File "/Users/runner/hostedtoolcache/node/14.21.3/x64/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/__init__.py", line 136, in Load
2024-10-22T07:59:38.1925600Z     result = gyp.input.Load(build_files, default_variables, includes[:],
2024-10-22T07:59:38.1954650Z              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-10-22T07:59:38.1973220Z   File "/Users/runner/hostedtoolcache/node/14.21.3/x64/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/input.py", line 2782, in Load
2024-10-22T07:59:38.2001460Z     LoadTargetBuildFile(build_file, data, aux_data,
2024-10-22T07:59:38.2025280Z   File "/Users/runner/hostedtoolcache/node/14.21.3/x64/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/input.py", line 391, in LoadTargetBuildFile
2024-10-22T07:59:38.2034940Z     build_file_data = LoadOneBuildFile(build_file_path, data, aux_data,
2024-10-22T07:59:38.2041310Z                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-10-22T07:59:38.2056210Z   File "/Users/runner/hostedtoolcache/node/14.21.3/x64/lib/node_modules/npm/node_modules/node-gyp/gyp/pylib/gyp/input.py", line 234, in LoadOneBuildFile
2024-10-22T07:59:38.2073940Z     build_file_contents = open(build_file_path, 'rU').read()
2024-10-22T07:59:38.2091500Z                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-10-22T07:59:38.2106680Z ValueError: invalid mode: 'rU' while trying to load binding.gyp
```